### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/Matrix/keywords.txt
+++ b/Matrix/keywords.txt
@@ -1,2 +1,2 @@
-Matrix   KEYWORD1
-showMatrix    KEYWORD2
+Matrix	KEYWORD1
+showMatrix	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords